### PR TITLE
Add dbname parameter and write additional ggplot2 theme documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 inst/rmarkdown/templates/cd-research---general/skeleton/skeleton.html
 docs
 docs/
+
+.DS_Store

--- a/R/council_theme.R
+++ b/R/council_theme.R
@@ -13,24 +13,46 @@
 #' @details
 #' # Council fonts
 #'
-#' If you wish to use Council fonts, you must have the following fonts installed:
+#' There are a few requirements needed if you want to use Council font families.
+#'
+#' 1. You must have the optional [`{showtext}`](https://github.com/yixuan/showtext)
+#'  and [`{sysfonts}`](https://github.com/yixuan/sysfonts) packages installed.
+#'
+#' 2. You must have the following fonts installed:
 #'   - HelveticaNeueLT Standard Light, Standard Condensed, and Standard Medium Condensed
 #'   - Arial Narrow
 #'   - Palatino Linotype
+#'   If you do not have the font files handy, contact a package author or your manager.
 #'
-#' You must also have the [showtext](https://github.com/yixuan/showtext) and [sysfonts](https://github.com/yixuan/sysfonts)
-#'  packages installed.
+#' 3. The font family and file names much match those listed below
+#'   - "HelveticaNeueLT Std Cn" = "HelveticaNeueLTStd-Cn.otf"
+#'   - "HelveticaNeueLT Std Lt" = "HelveticaNeueLTStd-Lt.otf"
+#'   - "Arial Narrow" ="ARIALN.TTF"
+#'   - "HelveticaNeueLT Std Med Cn" = "HelveticaNeueLTStd-MdCn.otf")
+#'   - "Palatino Linotype" = "pala.ttf"
+#'
+#' 4. Consider options for your OS
+#'   - On Windows, be sure that the fonts are installed for the entire system, not just a single user.
+#'     These are located in `C:/Windows/Fonts`.
+#'   - On Mac OSX, be sure that fonts are installed for the user. These are located in `~/Library/Fonts`.
+#'     Consider copying the entire system font directory (`/Library/Fonts`) to the user font directory for easy access.
 #'
 #' # Font size suggestions
 #'  If you are creating plots for a presentation, you should increase all font sizes.
 #'  Check the default font sizes in the presentation platform you are working in
-#'  and adjust from there.
+#'  and adjust from there. For example, Microsoft PowerPoint sets slide headings at 77 pnt and
+#'  body text at 46 pnt. You will likely want to make the plot title less than 77 pnt so you
+#'  can preserve the text hierarchy in the slide.
 #'
 #' # Theme modifications
 #'  If you wish to make changes to this theme template, such as removing
-#'  the legend, adusting text positons,  access the source code by typing
+#'  the legend, adjusting text positions,  access the source code by typing
 #'  `councilR::council_theme` in the console. You can then copy/paste the
-#'  function into whatever document you are working on and make changes.
+#'  function into whatever document you are working on and make changes there.
+#'  If you want to make a change to the default template, open an Issue on GitHub
+#'  and ask for the change to be made, and/or make the change yourself and make
+#'  a pull request.
+#'
 #'
 #' @return a [ggplot2::theme()] object
 #' @export

--- a/R/import_from_gis.R
+++ b/R/import_from_gis.R
@@ -1,22 +1,24 @@
 #' Import a dataset from ArcCatalog
 #'
-#' @param query a string with the database connection and feature class
+#' @param query character, string with the database connection and feature class
+#' @param dbname character, database name. Usually either `"GIS"` or `"GISLibrary"`
 #'
-#' @return an \code{sf} object
+#' @return an `sf` object
 #' @export
 #' @examples \dontrun{import_from_gis("GISTransit.dbo.PublicParcelsMetroCTUs")}
 #' @importFrom sf st_as_sf
 #' @importFrom odbc odbc dbConnect
 #' @importFrom DBI dbGetQuery dbDisconnect
 #' @importFrom tictoc tic toc
-import_from_gis <- function(query){
+import_from_gis <- function(query,
+                            dbname = "GISLibrary"){
   tictoc::tic()
 
-  if(DBI::dbCanConnect(odbc::odbc(), "GIS") != TRUE){
+  if(DBI::dbCanConnect(odbc::odbc(), dbname) != TRUE){
     stop("Database could not connect.")
   }
 
-  conn <- odbc::dbConnect(odbc::odbc(), "GIS")
+  conn <- odbc::dbConnect(odbc::odbc(), dbname)
 
   sf_df <- sf::st_as_sf(DBI::dbGetQuery(conn,
                                         paste0("SELECT *, Shape.STAsText() as wkt FROM ", query)),

--- a/man/council_theme.Rd
+++ b/man/council_theme.Rd
@@ -39,28 +39,55 @@ a \code{\link[ggplot2:theme]{ggplot2::theme()}} object
 Council ggplot2 theme
 }
 \section{Council fonts}{
-If you wish to use Council fonts, you must have the following fonts installed:
+There are a few requirements needed if you want to use Council font families.
+\enumerate{
+\item You must have the optional \href{https://github.com/yixuan/showtext}{\code{{showtext}}}
+and \href{https://github.com/yixuan/sysfonts}{\code{{sysfonts}}} packages installed.
+\item You must have the following fonts installed:
+}
 \itemize{
 \item HelveticaNeueLT Standard Light, Standard Condensed, and Standard Medium Condensed
 \item Arial Narrow
 \item Palatino Linotype
+If you do not have the font files handy, contact a package author or your manager.
 }
-
-You must also have the \href{https://github.com/yixuan/showtext}{showtext} and \href{https://github.com/yixuan/sysfonts}{sysfonts}
-packages installed.
+\enumerate{
+\item The font family and file names much match those listed below
+}
+\itemize{
+\item "HelveticaNeueLT Std Cn" = "HelveticaNeueLTStd-Cn.otf"
+\item "HelveticaNeueLT Std Lt" = "HelveticaNeueLTStd-Lt.otf"
+\item "Arial Narrow" ="ARIALN.TTF"
+\item "HelveticaNeueLT Std Med Cn" = "HelveticaNeueLTStd-MdCn.otf")
+\item "Palatino Linotype" = "pala.ttf"
+}
+\enumerate{
+\item Consider options for your OS
+}
+\itemize{
+\item On Windows, be sure that the fonts are installed for the entire system, not just a single user.
+These are located in \verb{C:/Windows/Fonts}.
+\item On Mac OSX, be sure that fonts are installed for the user. These are located in \verb{~/Library/Fonts}.
+Consider copying the entire system font directory (\verb{/Library/Fonts}) to the user font directory for easy access.
+}
 }
 
 \section{Font size suggestions}{
 If you are creating plots for a presentation, you should increase all font sizes.
 Check the default font sizes in the presentation platform you are working in
-and adjust from there.
+and adjust from there. For example, Microsoft PowerPoint sets slide headings at 77 pnt and
+body text at 46 pnt. You will likely want to make the plot title less than 77 pnt so you
+can preserve the text hierarchy in the slide.
 }
 
 \section{Theme modifications}{
 If you wish to make changes to this theme template, such as removing
-the legend, adusting text positons,  access the source code by typing
+the legend, adjusting text positions,  access the source code by typing
 \code{councilR::council_theme} in the console. You can then copy/paste the
-function into whatever document you are working on and make changes.
+function into whatever document you are working on and make changes there.
+If you want to make a change to the default template, open an Issue on GitHub
+and ask for the change to be made, and/or make the change yourself and make
+a pull request.
 }
 
 \seealso{

--- a/man/import_from_gis.Rd
+++ b/man/import_from_gis.Rd
@@ -4,10 +4,12 @@
 \alias{import_from_gis}
 \title{Import a dataset from ArcCatalog}
 \usage{
-import_from_gis(query)
+import_from_gis(query, dbname = "GISLibrary")
 }
 \arguments{
-\item{query}{a string with the database connection and feature class}
+\item{query}{character, string with the database connection and feature class}
+
+\item{dbname}{character, database name. Usually either \code{"GIS"} or \code{"GISLibrary"}}
 }
 \value{
 an \code{sf} object

--- a/tests/testthat/test-import_from_gis.R
+++ b/tests/testthat/test-import_from_gis.R
@@ -1,7 +1,7 @@
 test_that("error message is returnd", {
 
   if(DBI::dbCanConnect(odbc::odbc(), "GIS") != TRUE){
-    testthat::expect_error(import_from_gis("GISTransit.dbo.PublicParcelsMetroCTUs"))
+    testthat::expect_error(import_from_gis("GISTransit.dbo.PublicParcelsMetroCTUs", dbname = "GIS"))
   }
 
   })


### PR DESCRIPTION
This PR

-  Adds `dbname` as a parameter for `import_from_gis()`, which makes the function more specific, reliable, and less prone to bugs
- Adds detail to `council_theme()` documentation, outlining package requirements, file requirements, and OS considerations for using Council fonts, and font size considerations