### PR TITLE
Add snippets for metro and tile CRS codes

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -24,6 +24,7 @@ jobs:
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      R_CHECK_FORCE_SUGGESTS: false
       RSPM: ${{ matrix.config.rspm }}
 
     steps:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -24,7 +24,7 @@ jobs:
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      R_CHECK_FORCE_SUGGESTS: false
+      _R_CHECK_FORCE_SUGGESTS_: false
       RSPM: ${{ matrix.config.rspm }}
 
     steps:
@@ -49,7 +49,7 @@ jobs:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-r-${{ matrix.config.r }}-1-${{ hashFiles('.github/depends.Rds') }}
           restore-keys: ${{ runner.os }}-r-${{ matrix.config.r }}-1-
-          
+
       - name: Install dependencies
         run: |
           remotes::install_deps(dependencies = TRUE)

--- a/inst/snippets/r.snippets
+++ b/inst/snippets/r.snippets
@@ -20,6 +20,6 @@ snippet metro_centroid
 	c(-93.30375,
 		44.91831)
 snippet metro_crs
-	"26915"
+	26915
 snippet tile_crs
-	"4326"
+	4326

--- a/inst/snippets/r.snippets
+++ b/inst/snippets/r.snippets
@@ -19,3 +19,7 @@ snippet counties_mpo
 snippet metro_centroid
 	c(-93.30375,
 		44.91831)
+snippet metro_crs
+	"26915"
+snippet tile_crs
+	"4326"


### PR DESCRIPTION
This PR add two items to the R snippets template; `metro_crs` and `tile_crs`.  

`metro_crs` is `"26915"`, [NAD83/UTM Zone 15N](https://epsg.io/26915). Most Council and state datasets are stored with this CRS, as it is optimized for our region. This snippet is is helpful because CRS information is not always imported when reading in spatial data. You can use `sf::st_set_crs("26915")` to set the CRS.

`tile_crs` is `"4326"`, [WGS84](https://epsg.io/4326).  Google Maps, `{leaflet}` and most interactive mapping tools use this tile-based system. Most of these tools *only* take WGS84,  so you can transform the data from 26915 to 4326 with `sf::st_transform("4326")`. 
