### PR TITLE
theme_council() font error on Windows machines

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -36,8 +36,13 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: rcmdcheck
+          extra-packages: any::rcmdcheck
+          needs: check
 
-      - uses: r-lib/actions/check-r-package@v1
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          args: 'c("--no-manual", "--as-cran")'
+          error-on: '"error"'
+          check-dir: '"check"'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: councilR
 Title: Functions and Templates for the Metropolitan Council
-Version: 0.1.2.9000
+Version: 0.1.2.9001
 Date: 2022-03-15
 Authors@R: c(
     person("Metropolitan Council", role = "cph"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,5 +55,5 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
 Website: https://github.com/Metropolitan-Council/councilR

--- a/R/import_from_emissions.R
+++ b/R/import_from_emissions.R
@@ -1,6 +1,5 @@
 #' @title Import data table from greenhouse gas emissions scenario planning database
 #'
-#'
 #' @param table_name character, which table to pull.
 #' @param uid character, your network id.
 #'     Default is `getOption("councilR.uid")`. For example, `"mc\\rotenle"`

--- a/R/theme_council.R
+++ b/R/theme_council.R
@@ -1,6 +1,6 @@
-#' Council ggplot2 theme
+#' @title Council ggplot2 theme
 #'
-#' The default `theme_council()` plus a more simple `theme_council_open()` for making MetCouncil figures. `theme_council()` will be appropriate in most cases while `theme_council_open()` is appropriate for single scatterplots or line graphs.
+#' @description The default `theme_council()` plus a more simple `theme_council_open()` for making MetCouncil figures. `theme_council()` will be appropriate in most cases while `theme_council_open()` is appropriate for single scatterplots or line graphs.
 #'
 #' Please note that the y-axis text is horizontal, and long axis names will need to be wrapped; the `str_wrap` function from `stringr` will be useful. For example, consider using this piece of code: `labs(y = stringr::str_wrap("Axis labels are now horizontal, but you still need to insert some code to wrap long labels", width = 15))`
 #'

--- a/R/theme_council.R
+++ b/R/theme_council.R
@@ -105,7 +105,17 @@ theme_council <- function(base_size = 11,
     requireNamespace("showtext", quietly = TRUE)
 
     showtext::showtext_auto()
-    sysfonts::font_paths()
+    if(grepl("mac", osVersion)){
+      sysfonts::font_paths()
+    } else {
+      # if windows, add the user-level font files to font paths
+      sysfonts::font_paths(
+        paste0("C:\\Users\\",
+               Sys.info()["user"],
+               "\\AppData\\Local\\Microsoft\\Windows\\Fonts"))
+    }
+
+
     files <- sysfonts::font_files()
 
     sysfonts::font_add("HelveticaNeueLT Std Cn", "HelveticaNeueLTStd-Cn.otf")

--- a/README.Rmd
+++ b/README.Rmd
@@ -46,7 +46,8 @@ By contributing to this project, you agree to abide by its terms.
 
 Thanks to all the folks who have contributed to this project in one way or another
 
-[&#x0040;ashleyasmus](https://github.com/ashleyasmus), [&#x0040;ehesch](https://github.com/ehesch), [&#x0040;eroten](https://github.com/eroten), and [&#x0040;leonx075](https://github.com/leonx075).
+[&#x0040;ashleyasmus](https://github.com/ashleyasmus), [&#x0040;ehesch](https://github.com/ehesch), [&#x0040;eroten](https://github.com/eroten),
+[&#x0040;svelick](https://github.com/svelick), and [&#x0040;leonx075](https://github.com/leonx075).
 
 
 

--- a/README.md
+++ b/README.md
@@ -47,5 +47,6 @@ or another
 
 [@ashleyasmus](https://github.com/ashleyasmus),
 [@ehesch](https://github.com/ehesch),
-[@eroten](https://github.com/eroten), and
+[@eroten](https://github.com/eroten),
+[@svelick](https://github.com/svelick), and
 [@leonx075](https://github.com/leonx075).

--- a/man/theme_council.Rd
+++ b/man/theme_council.Rd
@@ -47,8 +47,7 @@ a \code{\link[ggplot2:theme]{ggplot2::theme()}} object
 }
 \description{
 The default \code{theme_council()} plus a more simple \code{theme_council_open()} for making MetCouncil figures. \code{theme_council()} will be appropriate in most cases while \code{theme_council_open()} is appropriate for single scatterplots or line graphs.
-}
-\details{
+
 Please note that the y-axis text is horizontal, and long axis names will need to be wrapped; the \code{str_wrap} function from \code{stringr} will be useful. For example, consider using this piece of code: \code{labs(y = stringr::str_wrap("Axis labels are now horizontal, but you still need to insert some code to wrap long labels", width = 15))}
 }
 \section{Council fonts}{


### PR DESCRIPTION
Some Windows users aren't able to install fonts system-wide, though they can install fonts within their user. However, `sysfonts::font_paths()` only looks for font files in the system-wide directory

```r
library(councilR)
library(sysfonts)
library(showtext)
#> Loading required package: showtextdb
font_add(regular="HelveticaNeueLTStd", "HelveticaNeueLTStd-Lt.otf")
#> Error in check_font_path(regular, "regular"): font file not found for 'regular' type
```

This patch creates a conditional in `theme_council()`, such that Windows users will load additional font paths and Mac users will be unaffected. 

Additional documentation fixes and Roxygen update are included. 

closes #37 