### PR TITLE
Qualify colors data lookup in theme_council() (#91)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,7 @@ Imports:
     tigris (>= 2.1),
     utils
 Suggests: 
+    callr (>= 3.7.0),
     citr (>= 0.3.2),
     cowplot (>= 1.1.1),
     curl (>= 4.3.2),

--- a/R/theme_council.R
+++ b/R/theme_council.R
@@ -189,21 +189,21 @@ theme_council <- function(base_size = 11,
 
     # SETUP -----
     line = ggplot2::element_line(
-      colour = colors$suppBlack,
+      colour = councilR::colors$suppBlack,
       linewidth = base_line_size,
       linetype = 1,
       lineend = "butt"
     ),
     rect = ggplot2::element_rect(
-      fill = colors$suppWhite,
-      colour = colors$suppBlack,
+      fill = councilR::colors$suppWhite,
+      colour = councilR::colors$suppBlack,
       linewidth = base_rect_size,
       linetype = 1
     ),
     text = ggplot2::element_text(
       family = base_family,
       face = "plain",
-      colour = colors$suppBlack,
+      colour = councilR::colors$suppBlack,
       size = base_size,
       lineheight = 0.9,
       hjust = 0.5,
@@ -368,7 +368,7 @@ theme_council <- function(base_size = 11,
     strip.switch.pad.wrap = ggplot2::unit(half_line / 2, "pt"),
 
     # PLOT -----
-    plot.background = ggplot2::element_rect(colour = colors$suppWhite),
+    plot.background = ggplot2::element_rect(colour = councilR::colors$suppWhite),
 
     ## title -----
     plot.title = ggplot2::element_text(

--- a/tests/testthat/test-theme_council.R
+++ b/tests/testthat/test-theme_council.R
@@ -80,3 +80,26 @@ test_that("geo theme is mostly blank", {
   testthat::expect_equal(th$panel.grid, ggplot2::element_blank())
   testthat::expect_equal(th$axis.text, ggplot2::element_blank())
 })
+
+test_that("theme_council() works without attaching councilR (#91)", {
+  # Calling councilR::theme_council() without library(councilR) used to error
+  # ("object of type 'closure' is not subsettable") because the bare `colors`
+  # references resolved to grDevices::colors rather than the package data.
+  # Run in a fresh process with no attach to guard against that regression.
+  testthat::skip_if_not_installed("councilR")
+  testthat::skip_if_not_installed("callr")
+
+  th <- callr::r(function() councilR::theme_council())
+  testthat::expect_s3_class(th, "theme")
+
+  # A full plot using the theme should also build without error.
+  p <- callr::r(function() {
+    df <- data.frame(v1 = 1:5, v2 = 6:10)
+    plot <- ggplot2::ggplot(df, ggplot2::aes(x = v1, y = v2)) +
+      ggplot2::geom_point(size = 4) +
+      councilR::theme_council()
+    ggplot2::ggplot_build(plot)$plot$theme
+    "ok"
+  })
+  testthat::expect_identical(p, "ok")
+})


### PR DESCRIPTION
Calling councilR::theme_council() without first running library(councilR) errored with "object of type closure is not subsettable", because the bare colors references in the theme resolved to grDevices::colors (a closure) instead of the package data. This qualifies the five colors$ lookups in theme_council() with councilR::colors$ so they always find the package data, which is the fix suggested in #91. I added a regression test that builds the theme and a small plot in a fresh session without attaching the package, so the unattached path stays covered. The same bare colors$ pattern also appears in scale_fill_council() and council_layout(), so you may want to qualify those too, but I kept this PR scoped to the theme_council() issue. Thanks for the helpful reprex.

Fixes #91